### PR TITLE
feat: 업비트 API 종목 데이터 저장 및 종목 현재가 정보 데이터 수집 스케줄러 추가

### DIFF
--- a/src/main/java/com/coin_notify/coin_notify/CoinNotifyApplication.java
+++ b/src/main/java/com/coin_notify/coin_notify/CoinNotifyApplication.java
@@ -2,12 +2,12 @@ package com.coin_notify.coin_notify;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CoinNotifyApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(CoinNotifyApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/coin_notify/coin_notify/controller/CoinMarketController.java
+++ b/src/main/java/com/coin_notify/coin_notify/controller/CoinMarketController.java
@@ -1,0 +1,23 @@
+package com.coin_notify.coin_notify.controller;
+
+import com.coin_notify.coin_notify.service.CoinService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class CoinMarketController {
+	private final CoinService coinService;
+
+	@Autowired
+	public CoinMarketController(CoinService coinService) {
+		this.coinService = coinService;
+	}
+
+	@GetMapping("/coin-collect")
+	public Mono<ResponseEntity<String>> process() {
+		return coinService.coinCollectionProcess().thenReturn(ResponseEntity.ok("ok"));
+	}
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/entity/BasicEntity.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/entity/BasicEntity.java
@@ -1,0 +1,18 @@
+package com.coin_notify.coin_notify.data.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.sql.Timestamp;
+
+@Getter
+@Setter
+public class BasicEntity {
+    @CreatedDate
+    private Timestamp createdAt;
+    @LastModifiedDate
+    private Timestamp updatedAt;
+    private Timestamp deletedAt;
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/entity/CoinEntity.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/entity/CoinEntity.java
@@ -1,0 +1,24 @@
+package com.coin_notify.coin_notify.data.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Getter
+@Setter
+@Table("coins")
+public class CoinEntity extends BasicEntity {
+    @Id
+    private Long id;
+
+    @Column("market")
+    private String market;
+
+    @Column("korean_name")
+    private String koreanName;
+
+    @Column("english_name")
+    private String englishName;
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/entity/RealTimePriceEntity.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/entity/RealTimePriceEntity.java
@@ -1,0 +1,75 @@
+package com.coin_notify.coin_notify.data.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Getter
+@Setter
+@Table("real_time_prices")
+public class RealTimePriceEntity extends BasicEntity {
+	@Id
+	private Long id;
+
+	@Column("coin_id")
+	private Long coinId;
+
+	@Column("trade_date") // 최근 거래 일자 (UTC)
+	private String tradeDate;
+
+	@Column("trade_time") // 최근 거래 시각 (UTC)
+	private String tradeTime;
+
+	@Column("trade_date_kst") // 최근 거래 일자 (KST)
+	private String tradeDateKst;
+
+	@Column("trade_time_kst") // 최근 거래 시각 (KST)
+	private String tradeTimeKst;
+
+	@Column("trade_timestamp") // 최근 거래 일시 (Unix Timestamp)
+	private Long tradeTimestamp;
+
+	@Column("opening_price") // 시가
+	private Double openingPrice;
+
+	@Column("high_price") // 고가
+	private Double highPrice;
+
+	@Column("low_price") // 저가
+	private Double lowPrice;
+
+	@Column("trade_price") // 종가 (현재가)
+	private Double tradePrice;
+
+	@Column("prev_closing_price") // 전일 종가
+	private Double prevClosingPrice;
+
+	@Column("change") // 상승/하락/보합
+	private String change;
+
+	@Column("change_price") // 변화액
+	private Double changePrice;
+
+	@Column("change_rate") // 변화율
+	private Double changeRate;
+
+	@Column("trade_volume") // 최근 거래량
+	private Double tradeVolume;
+
+	@Column("acc_trade_price") // 누적 거래대금 (UTC 0시 기준)
+	private Double accTradePrice;
+
+	@Column("acc_trade_price_24h") // 24시간 누적 거래대금
+	private Double accTradePrice24h;
+
+	@Column("acc_trade_volume") // 누적 거래량 (UTC 0시 기준)
+	private Double accTradeVolume;
+
+	@Column("acc_trade_volume_24h") // 24시간 누적 거래량
+	private Double accTradeVolume24h;
+
+	@Column("timestamp")
+	private Long timestamp;
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/repository/CoinRepository.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/repository/CoinRepository.java
@@ -1,0 +1,7 @@
+package com.coin_notify.coin_notify.data.repository;
+
+import com.coin_notify.coin_notify.data.entity.CoinEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+public interface CoinRepository extends ReactiveCrudRepository<CoinEntity, Long> {
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/repository/CoinRepository.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/repository/CoinRepository.java
@@ -1,7 +1,13 @@
 package com.coin_notify.coin_notify.data.repository;
 
 import com.coin_notify.coin_notify.data.entity.CoinEntity;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface CoinRepository extends ReactiveCrudRepository<CoinEntity, Long> {
+	@Query("SELECT market FROM coins")
+	Flux<String> findAllMarketNames();
+	Mono<CoinEntity> findByMarket(String market);
 }

--- a/src/main/java/com/coin_notify/coin_notify/data/repository/RealTimePriceRepository.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/repository/RealTimePriceRepository.java
@@ -1,0 +1,7 @@
+package com.coin_notify.coin_notify.data.repository;
+
+import com.coin_notify.coin_notify.data.entity.RealTimePriceEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+public interface RealTimePriceRepository extends ReactiveCrudRepository<RealTimePriceEntity, Long> {
+}

--- a/src/main/java/com/coin_notify/coin_notify/scheduler/PriceScheduler.java
+++ b/src/main/java/com/coin_notify/coin_notify/scheduler/PriceScheduler.java
@@ -1,0 +1,127 @@
+package com.coin_notify.coin_notify.scheduler;
+
+import com.coin_notify.coin_notify.data.entity.RealTimePriceEntity;
+import com.coin_notify.coin_notify.data.repository.CoinRepository;
+import com.coin_notify.coin_notify.data.repository.RealTimePriceRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+@Component
+public class PriceScheduler implements CommandLineRunner {
+	@Autowired
+	private CoinRepository coinRepository;
+
+	@Autowired
+	private RealTimePriceRepository realTimePriceRepository;
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+	public void run(String... args) throws Exception {
+		fetchRealTimePrice();
+	}
+
+	public void fetchRealTimePrice() {
+		coinRepository.findAllMarketNames()
+				.collectList()
+				.filter(markets -> !markets.isEmpty())
+				.map(markets -> String.join(",", markets))
+				.flatMap(this::callUpbitApiWithMarkets)
+				.flatMapMany(response -> {
+					try {
+						JsonNode root = objectMapper.readTree(response);
+
+						return Flux.fromIterable(root)
+								.flatMap(node -> {
+									String market = node.get("market").asText();
+									Double tradePrice = node.get("trade_price").asDouble();
+									String tradeDate = node.get("trade_date").asText();
+									String tradeTime = node.get("trade_time").asText();
+									String tradeDateKst = node.get("trade_date_kst").asText();
+									String tradeTimeKst = node.get("trade_time_kst").asText();
+									Long tradeTimestamp = node.get("trade_timestamp").asLong();
+									Double openingPrice = node.get("opening_price").asDouble();
+									Double highPrice = node.get("high_price").asDouble();
+									Double lowPrice = node.get("low_price").asDouble();
+									String change = node.get("change").asText();
+									Double changePrice = node.get("change_price").asDouble();
+									Double changeRate = node.get("change_rate").asDouble();
+									Double tradeVolume = node.get("trade_volume").asDouble();
+									Double accTradePrice = node.get("acc_trade_price").asDouble();
+									Double prevClosingPrice = node.get("prev_closing_price").asDouble();
+									Double accTradePrice24h = node.get("acc_trade_price_24h").asDouble();
+									Double accTradeVolume = node.get("acc_trade_volume").asDouble();
+									Double accTradeVolume24h = node.get("acc_trade_volume_24h").asDouble();
+									Long timestamp = node.get("timestamp").asLong();
+
+									return coinRepository.findByMarket(market)
+											.map(coin -> {
+												RealTimePriceEntity price = new RealTimePriceEntity();
+												price.setCoinId(coin.getId());
+												price.setTradePrice(tradePrice);
+												price.setTradeDate(tradeDate);
+												price.setTradeTime(tradeTime);
+												price.setTradeDateKst(tradeDateKst);
+												price.setTradeTimeKst(tradeTimeKst);
+												price.setTradeTimestamp(tradeTimestamp);
+												price.setOpeningPrice(openingPrice);
+												price.setHighPrice(highPrice);
+												price.setLowPrice(lowPrice);
+												price.setChange(change);
+												price.setChangePrice(changePrice);
+												price.setChangeRate(changeRate);
+												price.setTradeVolume(tradeVolume);
+												price.setAccTradePrice(accTradePrice);
+												price.setPrevClosingPrice(prevClosingPrice);
+												price.setAccTradePrice24h(accTradePrice24h);
+												price.setAccTradeVolume(accTradeVolume);
+												price.setAccTradeVolume24h(accTradeVolume24h);
+												price.setTimestamp(timestamp);
+												return price;
+											});
+								});
+					} catch (Exception e) {
+						e.printStackTrace();
+						return Flux.empty();
+					}
+				})
+				.flatMap(realTimePriceRepository::save)
+				.subscribe(saved -> System.out.println("-- 저장됨: "));
+
+	}
+
+	private Mono<String> callUpbitApiWithMarkets(String markets) {
+		try {
+			String serverUrl = "https://api.upbit.com/v1/ticker?markets=" + markets;
+
+			HttpClient client = HttpClient.newHttpClient();
+			HttpRequest request = HttpRequest.newBuilder()
+					.uri(URI.create(serverUrl))
+					.GET()
+					.build();
+
+			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+			if (response.statusCode() == 200) {
+				return Mono.just(response.body());
+			} else {
+				System.err.println("API 응답 에러: " + response.statusCode());
+				return Mono.error(new RuntimeException("API 호출 실패: " + response.statusCode()));
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+			return Mono.error(new RuntimeException("API 호출 중 예외 발생", e));
+		}
+	}
+}

--- a/src/main/java/com/coin_notify/coin_notify/scheduler/SchedulerTesterController.java
+++ b/src/main/java/com/coin_notify/coin_notify/scheduler/SchedulerTesterController.java
@@ -1,0 +1,23 @@
+package com.coin_notify.coin_notify.scheduler;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/scheduler-test")
+public class SchedulerTesterController {
+	private final PriceScheduler priceScheduler;
+
+	public SchedulerTesterController(
+			PriceScheduler priceScheduler
+	) {
+		this.priceScheduler = priceScheduler;
+	}
+
+	@GetMapping()
+	public String runSchedulerManually() {
+		priceScheduler.fetchRealTimePrice();
+		return "-- 스케줄러 수동 실행 완료!";
+	}
+}

--- a/src/main/java/com/coin_notify/coin_notify/service/CoinService.java
+++ b/src/main/java/com/coin_notify/coin_notify/service/CoinService.java
@@ -1,0 +1,57 @@
+package com.coin_notify.coin_notify.service;
+
+import com.coin_notify.coin_notify.data.entity.CoinEntity;
+import com.coin_notify.coin_notify.data.repository.CoinRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+@Service
+public class CoinService {
+	private final ObjectMapper objectMapper;
+	private final HttpClient client;
+	private final CoinRepository coinRepository;
+
+	public CoinService(ObjectMapper objectMapper, CoinRepository coinRepository) {
+		this.objectMapper = objectMapper;
+		this.coinRepository = coinRepository;
+		this.client = HttpClient.newHttpClient();
+	}
+
+	public Mono<Void> coinCollectionProcess() {
+		return fetchMarketData().flatMap(this::saveMarketData);
+	}
+
+	private Mono<JsonNode> fetchMarketData() {
+		String url = "https://api.upbit.com/v1/market/all?is_details=true";
+
+		HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).header("accept", "application/json").build();
+
+		return Mono.fromCallable(() -> {
+			try {
+				HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+				return objectMapper.readTree(response.body());
+			} catch (Exception e) {
+				throw new RuntimeException("Failed to fetch market data", e);
+			}
+		});
+	}
+
+	private Mono<Void> saveMarketData(JsonNode marketData) {
+		return Flux.fromIterable(marketData).map(coin -> {
+			CoinEntity coinEntity = new CoinEntity();
+			coinEntity.setMarket(coin.get("market").asText());
+			coinEntity.setKoreanName(coin.get("korean_name").asText());
+			coinEntity.setEnglishName(coin.get("english_name").asText());
+			System.out.println(coin.get("market_event"));
+			return coinEntity;
+		}).flatMap(coinRepository::save).doOnNext(saved -> System.out.println("Saved: " + saved.getMarket())).doOnError(error -> System.err.println("Error saving: " + error.getMessage())).then();
+	}
+}

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -1,0 +1,10 @@
+CREATE TABLE coins
+(
+    id           SERIAL PRIMARY KEY,
+    market       VARCHAR(255),
+    korean_name  VARCHAR(255),
+    english_name VARCHAR(255),
+    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted_at   TIMESTAMP DEFAULT NULL
+);

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -8,3 +8,32 @@ CREATE TABLE coins
     updated_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     deleted_at   TIMESTAMP DEFAULT NULL
 );
+
+CREATE TABLE real_time_prices
+(
+    id                   SERIAL PRIMARY KEY,                       -- 자동 증가하는 고유 ID
+    coin_id              BIGINT     NOT NULL,                      -- 코인 식별자 (coins 테이블의 PK)
+    trade_date           VARCHAR(8) NOT NULL,                      -- 최근 거래 일자 (UTC)
+    trade_time           VARCHAR(6) NOT NULL,                      -- 최근 거래 시각 (UTC)
+    trade_date_kst       VARCHAR(8) NOT NULL,                      -- 최근 거래 일자 (KST)
+    trade_time_kst       VARCHAR(6) NOT NULL,                      -- 최근 거래 시각 (KST)
+    trade_timestamp      BIGINT     NOT NULL,                      -- 최근 거래 일시 (Unix Timestamp)
+    opening_price        DOUBLE PRECISION,                         -- 시가
+    high_price           DOUBLE PRECISION,                         -- 고가
+    low_price            DOUBLE PRECISION,                         -- 저가
+    trade_price          DOUBLE PRECISION,                         -- 종가 (현재가)
+    prev_closing_price   DOUBLE PRECISION,                         -- 전일 종가
+    change               VARCHAR(4),                               -- 상승/하락/보합
+    change_price         DOUBLE PRECISION,                         -- 변화액
+    change_rate          DOUBLE PRECISION,                         -- 변화율
+    trade_volume         DOUBLE PRECISION,                         -- 가장 최근 거래량
+    acc_trade_price      DOUBLE PRECISION,                         -- 누적 거래대금 (UTC 0시 기준)
+    acc_trade_price_24h  DOUBLE PRECISION,                         -- 24시간 누적 거래대금
+    acc_trade_volume     DOUBLE PRECISION,                         -- 누적 거래량 (UTC 0시 기준)
+    acc_trade_volume_24h DOUBLE PRECISION,                         -- 24시간 누적 거래량
+    timestamp            BIGINT     NOT NULL,                      -- API 응답 시점 타임스탬프
+    created_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,      -- 생성 일시
+    updated_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,      -- 수정 일시
+    deleted_at           TIMESTAMP DEFAULT NULL,                   -- 삭제 일시
+    CONSTRAINT fk_coin FOREIGN KEY (coin_id) REFERENCES coins (id) -- 외래키 제약조건
+);


### PR DESCRIPTION
실시간 시세수집
- 업비트 종목 코드 조회 API 연동하여 coins 테이블에 데이터 저장 API 추가 
[업비트 개발자 센터 종목 코드 조회 ](https://docs.upbit.com/kr/reference/%EB%A7%88%EC%BC%93-%EC%BD%94%EB%93%9C-%EC%A1%B0%ED%9A%8C)
- 업비트 종목 단위 현재가 정보 API 연동하여 real_time_prices 테이블에 데이터 수집 및 1시간 주기 스케줄링 추가 
[업비트 개발자 센터 종목 단위 현재가 정보 ](https://docs.upbit.com/kr/reference/ticker%ED%98%84%EC%9E%AC%EA%B0%80-%EC%A0%95%EB%B3%B4)