### PR TITLE
feat: 관심 종목 가격 변동 감지 로직 추가

### DIFF
--- a/src/main/java/com/coin_notify/coin_notify/config/AppConfig.java
+++ b/src/main/java/com/coin_notify/coin_notify/config/AppConfig.java
@@ -1,0 +1,13 @@
+package com.coin_notify.coin_notify.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+	@Bean
+	public ObjectMapper objectMapper() {
+		return new ObjectMapper();
+	}
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/entity/LikeMarketEntity.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/entity/LikeMarketEntity.java
@@ -18,4 +18,9 @@ public class LikeMarketEntity extends BasicEntity {
 
 	@Column("market_id")
 	private Long marketId;
+
+	@Override
+	public String toString() {
+		return "데이터 확인 : {" + "marketId=" + marketId + '}';
+	}
 }

--- a/src/main/java/com/coin_notify/coin_notify/data/entity/MarketEntity.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/entity/MarketEntity.java
@@ -21,4 +21,9 @@ public class MarketEntity extends BasicEntity {
 
     @Column("english_name")
     private String englishName;
+
+    @Override
+    public String toString() {
+        return "데이터 확인 : {" + "marketCode=" + marketCode +  ", koreanName=" + koreanName + '}';
+    }
 }

--- a/src/main/java/com/coin_notify/coin_notify/data/repository/LikeMarketRepository.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/repository/LikeMarketRepository.java
@@ -2,8 +2,10 @@ package com.coin_notify.coin_notify.data.repository;
 
 import com.coin_notify.coin_notify.data.entity.LikeMarketEntity;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface LikeMarketRepository extends ReactiveCrudRepository<LikeMarketEntity, Long> {
 	Mono<LikeMarketEntity> findByUserIdAndMarketId(Long userId, Long marketId);
+	Flux<LikeMarketEntity> findAll();
 }

--- a/src/main/java/com/coin_notify/coin_notify/data/repository/MarketRepository.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/repository/MarketRepository.java
@@ -10,4 +10,7 @@ public interface MarketRepository extends ReactiveCrudRepository<MarketEntity, L
 	@Query("SELECT market_code FROM markets")
 	Flux<String> findAllMarketCodes();
 	Mono<MarketEntity> findByMarketCode(String marketCode);
+
+	@Query("SELECT * FROM markets WHERE id = :marketId")
+	Mono<MarketEntity> findByMarketId(Long marketId);
 }

--- a/src/main/java/com/coin_notify/coin_notify/data/repository/RealTimePriceRepository.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/repository/RealTimePriceRepository.java
@@ -1,7 +1,11 @@
 package com.coin_notify.coin_notify.data.repository;
 
 import com.coin_notify.coin_notify.data.entity.RealTimePriceEntity;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 
 public interface RealTimePriceRepository extends ReactiveCrudRepository<RealTimePriceEntity, Long> {
+	@Query("SELECT * FROM real_time_prices WHERE market_id = :marketId ORDER BY trade_timestamp DESC LIMIT 2")
+	Flux<RealTimePriceEntity> findRecentPrices(Long marketId);
 }

--- a/src/main/java/com/coin_notify/coin_notify/scheduler/PriceScheduler.java
+++ b/src/main/java/com/coin_notify/coin_notify/scheduler/PriceScheduler.java
@@ -1,11 +1,11 @@
 package com.coin_notify.coin_notify.scheduler;
 
 import com.coin_notify.coin_notify.data.entity.RealTimePriceEntity;
+import com.coin_notify.coin_notify.data.repository.LikeMarketRepository;
 import com.coin_notify.coin_notify.data.repository.MarketRepository;
 import com.coin_notify.coin_notify.data.repository.RealTimePriceRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -19,12 +19,17 @@ import java.net.http.HttpResponse;
 
 @Component
 public class PriceScheduler implements CommandLineRunner {
-	@Autowired
-	private MarketRepository marketRepository;
+	private final MarketRepository marketRepository;
+	private final LikeMarketRepository likeMarketRepository;
+	private final RealTimePriceRepository realTimePriceRepository;
+	private final ObjectMapper objectMapper;
 
-	@Autowired
-	private RealTimePriceRepository realTimePriceRepository;
-	private final ObjectMapper objectMapper = new ObjectMapper();
+	public PriceScheduler(MarketRepository marketRepository, LikeMarketRepository likeMarketRepository, RealTimePriceRepository realTimePriceRepository, ObjectMapper objectMapper) {
+		this.marketRepository = marketRepository;
+		this.likeMarketRepository = likeMarketRepository;
+		this.realTimePriceRepository = realTimePriceRepository;
+		this.objectMapper = objectMapper;
+	}
 
 	@Override
 	public void run(String... args) throws Exception {
@@ -36,69 +41,105 @@ public class PriceScheduler implements CommandLineRunner {
 		marketRepository.findAllMarketCodes()
 				.collectList()
 				.filter(markets -> !markets.isEmpty())
-				.map(markets -> String.join(",", markets))
+				.map(markets -> String.join(",",
+						markets))
 				.flatMap(this::callUpbitApiWithMarkets)
 				.flatMapMany(response -> {
 					try {
 						JsonNode root = objectMapper.readTree(response);
 
-						return Flux.fromIterable(root)
-								.flatMap(node -> {
-									String name = node.get("market").asText();
-									Double tradePrice = node.get("trade_price").asDouble();
-									String tradeDate = node.get("trade_date").asText();
-									String tradeTime = node.get("trade_time").asText();
-									String tradeDateKst = node.get("trade_date_kst").asText();
-									String tradeTimeKst = node.get("trade_time_kst").asText();
-									Long tradeTimestamp = node.get("trade_timestamp").asLong();
-									Double openingPrice = node.get("opening_price").asDouble();
-									Double highPrice = node.get("high_price").asDouble();
-									Double lowPrice = node.get("low_price").asDouble();
-									String change = node.get("change").asText();
-									Double changePrice = node.get("change_price").asDouble();
-									Double changeRate = node.get("change_rate").asDouble();
-									Double tradeVolume = node.get("trade_volume").asDouble();
-									Double accTradePrice = node.get("acc_trade_price").asDouble();
-									Double prevClosingPrice = node.get("prev_closing_price").asDouble();
-									Double accTradePrice24h = node.get("acc_trade_price_24h").asDouble();
-									Double accTradeVolume = node.get("acc_trade_volume").asDouble();
-									Double accTradeVolume24h = node.get("acc_trade_volume_24h").asDouble();
-									Long timestamp = node.get("timestamp").asLong();
+						return Flux.fromIterable(root).flatMap(node -> {
+							String name = node.get("market").asText();
+							Double tradePrice = node.get("trade_price").asDouble();
+							String tradeDate = node.get("trade_date").asText();
+							String tradeTime = node.get("trade_time").asText();
+							String tradeDateKst = node.get("trade_date_kst").asText();
+							String tradeTimeKst = node.get("trade_time_kst").asText();
+							Long tradeTimestamp = node.get("trade_timestamp").asLong();
+							Double openingPrice = node.get("opening_price").asDouble();
+							Double highPrice = node.get("high_price").asDouble();
+							Double lowPrice = node.get("low_price").asDouble();
+							String change = node.get("change").asText();
+							Double changePrice = node.get("change_price").asDouble();
+							Double changeRate = node.get("change_rate").asDouble();
+							Double tradeVolume = node.get("trade_volume").asDouble();
+							Double accTradePrice = node.get("acc_trade_price").asDouble();
+							Double prevClosingPrice = node.get("prev_closing_price").asDouble();
+							Double accTradePrice24h = node.get("acc_trade_price_24h").asDouble();
+							Double accTradeVolume = node.get("acc_trade_volume").asDouble();
+							Double accTradeVolume24h = node.get("acc_trade_volume_24h").asDouble();
+							Long timestamp = node.get("timestamp").asLong();
 
-									return marketRepository.findByMarketCode(name)
-											.map(market -> {
-												RealTimePriceEntity price = new RealTimePriceEntity();
-												price.setMarketId(market.getId());
-												price.setTradePrice(tradePrice);
-												price.setTradeDate(tradeDate);
-												price.setTradeTime(tradeTime);
-												price.setTradeDateKst(tradeDateKst);
-												price.setTradeTimeKst(tradeTimeKst);
-												price.setTradeTimestamp(tradeTimestamp);
-												price.setOpeningPrice(openingPrice);
-												price.setHighPrice(highPrice);
-												price.setLowPrice(lowPrice);
-												price.setChange(change);
-												price.setChangePrice(changePrice);
-												price.setChangeRate(changeRate);
-												price.setTradeVolume(tradeVolume);
-												price.setAccTradePrice(accTradePrice);
-												price.setPrevClosingPrice(prevClosingPrice);
-												price.setAccTradePrice24h(accTradePrice24h);
-												price.setAccTradeVolume(accTradeVolume);
-												price.setAccTradeVolume24h(accTradeVolume24h);
-												price.setTimestamp(timestamp);
-												return price;
-											});
-								});
+							return marketRepository.findByMarketCode(name).map(market -> {
+								RealTimePriceEntity price = new RealTimePriceEntity();
+								price.setMarketId(market.getId());
+								price.setTradePrice(tradePrice);
+								price.setTradeDate(tradeDate);
+								price.setTradeTime(tradeTime);
+								price.setTradeDateKst(tradeDateKst);
+								price.setTradeTimeKst(tradeTimeKst);
+								price.setTradeTimestamp(tradeTimestamp);
+								price.setOpeningPrice(openingPrice);
+								price.setHighPrice(highPrice);
+								price.setLowPrice(lowPrice);
+								price.setChange(change);
+								price.setChangePrice(changePrice);
+								price.setChangeRate(changeRate);
+								price.setTradeVolume(tradeVolume);
+								price.setAccTradePrice(accTradePrice);
+								price.setPrevClosingPrice(prevClosingPrice);
+								price.setAccTradePrice24h(accTradePrice24h);
+								price.setAccTradeVolume(accTradeVolume);
+								price.setAccTradeVolume24h(accTradeVolume24h);
+								price.setTimestamp(timestamp);
+								return price;
+							});
+						});
 					} catch (Exception e) {
 						e.printStackTrace();
 						return Flux.empty();
 					}
 				})
 				.flatMap(realTimePriceRepository::save)
-				.subscribe(saved -> System.out.println("-- 저장됨: "));
+				.then(checkLikeMarket())
+				.subscribe(unused -> {},
+						error -> System.err.println("에러 발생: " + error.getMessage()),
+						() -> System.out.println("fetchRealTimePrice + checkLikeMarket 완료"));
+	}
 
+	public Mono<Void> checkLikeMarket() {
+		return likeMarketRepository.findAll().flatMap(likeMarket -> {
+			Long marketId = likeMarket.getMarketId();
+			return marketRepository.findByMarketId(marketId).flatMap(market -> {
+				String marketCode = market.getMarketCode();
+				String marketKrName = market.getKoreanName();
+				String marketEnName = market.getEnglishName();
+
+				return realTimePriceRepository.findRecentPrices(marketId)
+						.collectList()
+						.filter(prices -> prices.size() >= 2)
+						.flatMap(prices -> {
+							RealTimePriceEntity latest = prices.get(0);
+							RealTimePriceEntity previous = prices.get(1);
+							double currentPrice = latest.getTradePrice();
+							double previousPrice = previous.getTradePrice();
+							double changeRate = Math.abs((currentPrice - previousPrice) / previousPrice);
+
+							if (changeRate >= 0.000000001) {
+								System.out.printf("📢 관심 종목 가격 변동 (0.000000001%% 이상): marketId %s | %s | %s | %s | 이전: %.2f -> 현재: %.2f (%.10f%%)%n",
+										marketId,
+										marketCode,
+										marketKrName,
+										marketEnName,
+										previousPrice,
+										currentPrice,
+										changeRate * 100);
+							}
+
+							return Mono.empty();
+						});
+			});
+		}).then();
 	}
 
 	private Mono<String> callUpbitApiWithMarkets(String markets) {
@@ -106,12 +147,10 @@ public class PriceScheduler implements CommandLineRunner {
 			String serverUrl = "https://api.upbit.com/v1/ticker?markets=" + markets;
 
 			HttpClient client = HttpClient.newHttpClient();
-			HttpRequest request = HttpRequest.newBuilder()
-					.uri(URI.create(serverUrl))
-					.GET()
-					.build();
+			HttpRequest request = HttpRequest.newBuilder().uri(URI.create(serverUrl)).GET().build();
 
-			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+			HttpResponse<String> response = client.send(request,
+					HttpResponse.BodyHandlers.ofString());
 
 			if (response.statusCode() == 200) {
 				return Mono.just(response.body());
@@ -121,7 +160,8 @@ public class PriceScheduler implements CommandLineRunner {
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
-			return Mono.error(new RuntimeException("API 호출 중 예외 발생", e));
+			return Mono.error(new RuntimeException("API 호출 중 예외 발생",
+					e));
 		}
 	}
 }


### PR DESCRIPTION
- 변동률 0.000000001% 이상일 때 출력
- 최근 2개의 실시간 가격 데이터 비교
- 변동률이 기준 이상일 경우 콘솔 로그 출력
- PriceScheduler 의존성 주입 방식으로 수정